### PR TITLE
fix(auth): restore per-client signup rate limiting

### DIFF
--- a/apps/backend/src/routes/auth/signup.ts
+++ b/apps/backend/src/routes/auth/signup.ts
@@ -14,7 +14,6 @@ export const signupHandler = new Elysia()
 			scoping: "global",
 			max: 50,
 			duration: 5 * 60 * 1000,
-			generator: () => "", // global limit
 			errorResponse: new RateLimitError(),
 		})
 	)


### PR DESCRIPTION
### Motivation
- Prevent a registration denial-of-service caused by the signup route supplying a constant generator key so every request shared a single rate-limit bucket.

### Description
- Remove the custom `generator: () => ""` override from the `rateLimit` configuration in `apps/backend/src/routes/auth/signup.ts` so the plugin's default key generation (client address) is used, preserving `max`, `duration` and `errorResponse`.

### Testing
- Ran `bunx --bun biome check apps/backend/src/routes/auth/signup.ts` which completed successfully.
- Ran `bun test apps/backend/tests/e2e/auth.test.ts` which could not complete in this environment because the generated Prisma client is missing and the tests error on import, causing the test run to fail.
- Attempted `bun run --cwd packages/db gen` which failed in this environment because `DATABASE_URL` is not set, preventing Prisma client generation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bd678817dc8330ac9396d4cd4d1846)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

- Removed the `generator: () => ""` option from the `rateLimit` configuration in the signup handler (`apps/backend/src/routes/auth/signup.ts`), allowing the rate limiter to use its default per-client key generation based on client IP address instead of a constant value, thereby restoring per-client rate limiting and closing a registration denial-of-service vulnerability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->