### PR TITLE
chore: add `db:deploy` in scripts, set username of DATABASE_URL in example  env to cvsa

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -1,1 +1,1 @@
-DATABASE_URL=postgres://username:password@localhost:5432/cvsa
+DATABASE_URL=postgres://cvsa:password@localhost:5432/cvsa

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
 		"format": "biome format --write .",
 		"test": "bunx --bun turbo run test",
 		"test:coverage": "bunx --bun turbo run test:coverage",
-		"typecheck": "bunx --bun turbo typecheck"
+		"typecheck": "bunx --bun turbo typecheck",
+		"db:deploy": "bunx --bun turbo db:deploy"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.8",

--- a/packages/core/.env.example
+++ b/packages/core/.env.example
@@ -1,1 +1,1 @@
-DATABASE_URL=postgres://username:password@localhost:5432/cvsa
+DATABASE_URL=postgres://cvsa:password@localhost:5432/cvsa

--- a/packages/db/.env.example
+++ b/packages/db/.env.example
@@ -1,1 +1,1 @@
-DATABASE_URL=postgres://username:password@localhost:5432/cvsa
+DATABASE_URL=postgres://cvsa:password@localhost:5432/cvsa

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -7,6 +7,7 @@
 		"migrate": "bunx --bun prisma migrate dev --create-only",
 		"migrate:dev": "bunx --bun prisma migrate dev",
 		"push": "bunx --bun prisma db push",
+		"db:deploy": "bunx --bun prisma migrate deploy",
 		"test:setup": "NODE_ENV=test bunx --bun prisma migrate reset --force",
 		"studio": "bunx --bun prisma studio",
 		"typecheck": "bunx --bun tsc --noEmit"

--- a/turbo.json
+++ b/turbo.json
@@ -15,6 +15,7 @@
 		},
 		"lint": {},
 		"test": {},
-		"test:coverage": {}
+		"test:coverage": {},
+		"db:deploy": {}
 	}
 }


### PR DESCRIPTION
## Summary by Sourcery

Add a top-level database deployment script and align database package and configuration to support it.

Build:
- Add a root-level db:deploy npm script wired to the Turbo pipeline.
- Expose a db:deploy script in the db package to run Prisma migrate deploy.
- Adjust environment example files and Turbo configuration to reference the new database deployment setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added `db:deploy` npm script in root `package.json` that runs `bunx --bun turbo db:deploy`
- Added `db:deploy` npm script in `packages/db/package.json` that runs `bunx --bun prisma migrate deploy`
- Added `db:deploy` task definition in `turbo.json` for the Turbo monorepo pipeline
- Updated PostgreSQL username in `apps/backend/.env.example` from `username` to `cvsa`
- Updated PostgreSQL username in `packages/core/.env.example` from `username` to `cvsa`
- Updated PostgreSQL username in `packages/db/.env.example` from `username` to `cvsa`
- Fixed missing newline at end of file in `apps/backend/.env.example` and `packages/db/.env.example`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->