### PR TITLE
feat(song): support creating relations in POST /v2/song

### DIFF
--- a/apps/backend/tests/song.test.ts
+++ b/apps/backend/tests/song.test.ts
@@ -7,9 +7,18 @@ const api = treaty(app);
 
 describe("Song E2E Tests", () => {
 	beforeEach(async () => {
+		await prisma.creation.deleteMany();
+		await prisma.performance.deleteMany();
+		await prisma.lyrics.deleteMany();
+		await prisma.song.deleteMany();
+		await prisma.voicebank.deleteMany();
+		await prisma.svsEngineVersion.deleteMany();
+		await prisma.svsEngine.deleteMany();
+		await prisma.singer.deleteMany();
+		await prisma.artistRole.deleteMany();
+		await prisma.artist.deleteMany();
 		await prisma.session.deleteMany();
 		await prisma.user.deleteMany();
-		await prisma.song.deleteMany();
 	});
 
 	afterAll(async () => {
@@ -26,6 +35,115 @@ describe("Song E2E Tests", () => {
 		});
 		return signup.data?.data.token;
 	}
+
+	describe("POST /v2/song - Create Song with relations", () => {
+		let singerId: number;
+		let artistId: number;
+		let roleId: number;
+
+		beforeEach(async () => {
+			const singer = await prisma.singer.create({ data: { name: "Test Singer" } });
+			singerId = singer.id;
+
+			const artist = await prisma.artist.create({ data: { name: "Test Artist" } });
+			artistId = artist.id;
+
+			const role = await prisma.artistRole.create({ data: { role: "composer" } });
+			roleId = role.id;
+		});
+
+		test("should create a song with lyrics", async () => {
+			const { data, status } = await api.v2.song.post({
+				name: "Song With Lyrics",
+				lyrics: [{ language: "zh", plainText: "歌词内容" }],
+			});
+
+			expect(status).toBe(201);
+			const lyricsRows = await prisma.lyrics.findMany({ where: { songId: (data as any).id } });
+			expect(lyricsRows).toHaveLength(1);
+			expect(lyricsRows[0].language).toBe("zh");
+			expect(lyricsRows[0].plainText).toBe("歌词内容");
+		});
+
+		test("should create a song with performances (singers)", async () => {
+			const { data, status } = await api.v2.song.post({
+				name: "Song With Singer",
+				performances: [{ singerId }],
+			});
+
+			expect(status).toBe(201);
+			const rows = await prisma.performance.findMany({ where: { songId: (data as any).id } });
+			expect(rows).toHaveLength(1);
+			expect(rows[0].singerId).toBe(singerId);
+		});
+
+		test("should create a song with creations (artists)", async () => {
+			const { data, status } = await api.v2.song.post({
+				name: "Song With Artist",
+				creations: [{ artistId, roleId }],
+			});
+
+			expect(status).toBe(201);
+			const rows = await prisma.creation.findMany({ where: { songId: (data as any).id } });
+			expect(rows).toHaveLength(1);
+			expect(rows[0].artistId).toBe(artistId);
+			expect(rows[0].artistRoleId).toBe(roleId);
+		});
+
+		test("should create a song with all relations at once", async () => {
+			const { data, status } = await api.v2.song.post({
+				name: "Full Song",
+				type: "ORIGINAL",
+				duration: 180,
+				performances: [{ singerId }],
+				creations: [{ artistId, roleId }],
+				lyrics: [
+					{ language: "en", plainText: "Hello world" },
+					{ language: "zh", plainText: "你好世界" },
+				],
+			});
+
+			expect(status).toBe(201);
+			const id = (data as any).id;
+			const [perfs, creations, lyrics] = await Promise.all([
+				prisma.performance.findMany({ where: { songId: id } }),
+				prisma.creation.findMany({ where: { songId: id } }),
+				prisma.lyrics.findMany({ where: { songId: id } }),
+			]);
+			expect(perfs).toHaveLength(1);
+			expect(creations).toHaveLength(1);
+			expect(lyrics).toHaveLength(2);
+		});
+
+		test("should return 422 when singerId does not exist", async () => {
+			const { status, error } = await api.v2.song.post({
+				performances: [{ singerId: 999999 }],
+			});
+
+			expect(status).toBe(422);
+			// @ts-expect-error – tracked in elysiajs/elysia#1248
+			expect(error?.value?.code).toBe("INVALID_RELATION_ID");
+		});
+
+		test("should return 422 when voicebank does not belong to singer", async () => {
+			const otherSinger = await prisma.singer.create({ data: { name: "Other Singer" } });
+			const engine = await prisma.svsEngine.create({ data: { name: "VOCALOID" } });
+			const version = await prisma.svsEngineVersion.create({
+				data: { versionString: "5.0", svsEngineId: engine.id },
+			});
+			const voicebank = await prisma.voicebank.create({
+				data: { singerId: otherSinger.id, svsEngineVersionId: version.id, language: "zh" },
+			});
+
+			const { status, error } = await api.v2.song.post({
+				performances: [{ singerId, voicebankId: voicebank.id }],
+			});
+
+			expect(status).toBe(422);
+			// @ts-expect-error – tracked in elysiajs/elysia#1248
+			expect(error?.value?.code).toBe("INCONSISTENT_SINGER_RELATION");
+		});
+	});
 
 	describe("POST /v2/song - Create Song", () => {
 		test("should create a song with authentication", async () => {

--- a/packages/core/modules/catalog/song/dto.ts
+++ b/packages/core/modules/catalog/song/dto.ts
@@ -16,6 +16,13 @@ const CreatePerformanceSchema = z.object({
 	svsEngineVersionId: z.int().positive().nullish(),
 });
 
+const CreateLyricsSchema = z.object({
+	language: z.string().optional().nullable(),
+	plainText: z.string().optional().nullable(),
+	ttml: z.string().optional().nullable(),
+	lrc: z.string().optional().nullable(),
+});
+
 export const CreateSongRequestSchema = z.object({
 	type: SongTypeSchema.nullish(),
 	name: z.string().nullish(),
@@ -25,6 +32,7 @@ export const CreateSongRequestSchema = z.object({
 	publishedAt: z.iso.datetime().nullish(),
 	performances: z.array(CreatePerformanceSchema).optional(),
 	creations: z.array(CreateCreationSchema).optional(),
+	lyrics: z.array(CreateLyricsSchema).optional(),
 });
 
 export const UpdateSongRequestSchema = z.object({

--- a/packages/core/modules/catalog/song/repository.ts
+++ b/packages/core/modules/catalog/song/repository.ts
@@ -6,10 +6,85 @@ import type {
 	SongDetailsResponseDto,
 } from "./dto";
 import type { ISongRepository } from "./repository.interface";
-import { transformPrismaResult, type TxClient } from "@cvsa/core/common";
+import { AppError, transformPrismaResult, type TxClient } from "@cvsa/core/common";
+
+type PerformanceInput = NonNullable<CreateSongRequestDto["performances"]>[number];
 
 export class SongRepository implements ISongRepository {
 	constructor(private readonly prisma: PrismaClient) {}
+
+	private async validatePerformances(
+		performances: PerformanceInput[],
+		db: TxClient
+	): Promise<void> {
+		for (const perf of performances) {
+			// Step 1: Verify singer exists
+			const singer = await db.singer.findUnique({
+				where: { id: perf.singerId },
+				select: { id: true },
+			});
+			if (!singer) {
+				throw new AppError("One or more referenced IDs do not exist", "INVALID_RELATION_ID", 422);
+			}
+
+			// Step 2: Verify optional referenced IDs
+			const voicebank =
+				perf.voicebankId != null
+					? await db.voicebank.findUnique({
+							where: { id: perf.voicebankId },
+							select: { singerId: true, svsEngineVersionId: true },
+						})
+					: null;
+			if (perf.voicebankId != null && !voicebank) {
+				throw new AppError("One or more referenced IDs do not exist", "INVALID_RELATION_ID", 422);
+			}
+
+			const engineVersion =
+				perf.svsEngineVersionId != null
+					? await db.svsEngineVersion.findUnique({
+							where: { id: perf.svsEngineVersionId },
+							select: { svsEngineId: true },
+						})
+					: null;
+			if (perf.svsEngineVersionId != null && !engineVersion) {
+				throw new AppError("One or more referenced IDs do not exist", "INVALID_RELATION_ID", 422);
+			}
+
+			const engine =
+				perf.svsEngineId != null
+					? await db.svsEngine.findUnique({
+							where: { id: perf.svsEngineId },
+							select: { id: true },
+						})
+					: null;
+			if (perf.svsEngineId != null && !engine) {
+				throw new AppError("One or more referenced IDs do not exist", "INVALID_RELATION_ID", 422);
+			}
+
+			// Step 3: Cross-entity consistency checks
+			if (voicebank && voicebank.singerId !== perf.singerId) {
+				throw new AppError(
+					"Voicebank does not belong to the specified singer",
+					"INCONSISTENT_SINGER_RELATION",
+					422
+				);
+			}
+			if (voicebank && engineVersion && voicebank.svsEngineVersionId !== perf.svsEngineVersionId) {
+				throw new AppError(
+					"Voicebank is not associated with the specified engine version",
+					"INCONSISTENT_SINGER_RELATION",
+					422
+				);
+			}
+			if (engineVersion && engine && engineVersion.svsEngineId !== perf.svsEngineId) {
+				throw new AppError(
+					"Engine version does not belong to the specified engine",
+					"INCONSISTENT_SINGER_RELATION",
+					422
+				);
+			}
+		}
+	}
 
 	async getById(id: SongId, tx?: TxClient) {
 		const client = tx ?? this.prisma;
@@ -76,29 +151,43 @@ export class SongRepository implements ISongRepository {
 
 	async create(input: CreateSongRequestDto, tx?: TxClient) {
 		const client = tx ?? this.prisma;
-		const { performances, creations, ...songData } = input;
+		const { performances, creations, lyrics, ...songData } = input;
 
-		return transformPrismaResult(
-			await client.song.create({
-				data: {
-					type: songData.type ?? null,
-					name: songData.name ?? null,
-					duration: songData.duration ?? null,
-					description: songData.description ?? null,
-					coverUrl: songData.coverUrl ?? null,
-					publishedAt: songData.publishedAt ?? null,
-					performances: performances && {
-						create: performances,
+		if (performances?.length) {
+			await this.validatePerformances(performances, client);
+		}
+
+		try {
+			return transformPrismaResult(
+				await client.song.create({
+					data: {
+						type: songData.type ?? null,
+						name: songData.name ?? null,
+						duration: songData.duration ?? null,
+						description: songData.description ?? null,
+						coverUrl: songData.coverUrl ?? null,
+						publishedAt: songData.publishedAt ?? null,
+						performances: performances && {
+							create: performances,
+						},
+						creations: creations && {
+							create: creations.map((c) => ({
+								artistId: c.artistId,
+								artistRoleId: c.roleId,
+							})),
+						},
+						lyrics: lyrics && {
+							create: lyrics,
+						},
 					},
-					creations: creations && {
-						create: creations.map((c) => ({
-							artistId: c.artistId,
-							artistRoleId: c.roleId,
-						})),
-					},
-				},
-			})
-		);
+				})
+			);
+		} catch (e) {
+			if (typeof e === "object" && e !== null && "code" in e && e.code === "P2003") {
+				throw new AppError("One or more referenced IDs do not exist", "INVALID_RELATION_ID", 422);
+			}
+			throw e;
+		}
 	}
 
 	async update(id: SongId, input: UpdateSongRequestDto, tx?: TxClient) {


### PR DESCRIPTION
## Summary

Closes #35

Implements support for creating song relations (singers/performances, artists/creations, lyrics) in `POST /v2/song`, adapted to the `develop` branch architecture (`packages/core` + `Performance`/`Creation`/`Lyrics` models).

- Add `CreateLyricsSchema` and `lyrics` field to `CreateSongRequestSchema` in `packages/core`
- Add `lyrics` creation in `SongRepository.create()`
- Add `validatePerformances()` for singer/voicebank/engine consistency checks (adapted from feature branch — without `singerSvsEngine` join tables not present in this branch's schema)
- Add P2003 FK error handling mapped to `INVALID_RELATION_ID`
- Add E2E tests covering performances, creations, lyrics, and invalid relation IDs

## Notes on naming

This branch uses `performances` (singers) and `creations` (artists) per the existing `develop` conventions, which differ from the `feat/song-create-relations` branch based on `main`.

## Checklist

- [x] `CreateSongRequestSchema` and `CreateSongRequestDto` has `performances` (singers), `creations` (artists), and `lyrics` field
- [x] `SongRepository.create` can create corresponding relations presented in the request body
- [x] Corresponding backend E2E tests was added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

### Test Suite (apps/backend/tests/song.test.ts)
- Expanded test database cleanup to delete related entities (`creation`, `performance`, `lyrics`, `voicebank`, `svsEngineVersion`, `svsEngine`, `singer`, `artistRole`, `artist`) in addition to `session` and `user`
- Removed redundant `prisma.song.deleteMany()` call from cleanup block
- Added new test suite for `POST /v2/song - Create Song with relations` that:
  - Creates prerequisite singer/artist/role records for testing
  - Validates creation of `lyrics` rows with expected `language` and `plainText`
  - Validates creation of `performance` rows with matching `singerId`
  - Validates creation of `creation` rows with matching `artistId` and `artistRoleId`
  - Tests combined payloads with multiple `lyrics`, `performances`, and `creations`
- Added negative-path tests for:
  - Returns HTTP `422` with `INVALID_RELATION_ID` error code when `singerId` does not exist
  - Returns HTTP `422` with `INCONSISTENT_SINGER_RELATION` error code when `voicebankId` belongs to a different singer

### Schema Definition (packages/core/modules/catalog/song/dto.ts)
- Added new `CreateLyricsSchema` with optional fields: `language`, `plainText`, `ttml`, `lrc`
- Extended `CreateSongRequestSchema` to include optional `lyrics` array property

### Repository Logic (packages/core/modules/catalog/song/repository.ts)
- Added `validatePerformances()` helper method that validates:
  - Singer existence
  - Voicebank/engine-version/engine existence and consistency
  - Voicebank belongs to correct singer
  - Voicebank version matches expected version
  - Engine version matches expected engine
  - Throws `AppError` with `INVALID_RELATION_ID` or `INCONSISTENT_SINGER_RELATION` codes on validation failure
- Updated `create()` method to:
  - Accept `lyrics` from request and persist via `lyrics: { create: lyrics }` during song creation
  - Run `validatePerformances()` when performances are present
  - Wrap Prisma `song.create` call in try/catch to translate Prisma `P2003` foreign-key errors to `INVALID_RELATION_ID` error code (HTTP 422)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->