### PR TITLE
feat(song): add lyrics support and fix relation creation in POST /v2/song

### DIFF
--- a/apps/backend/tests/song.test.ts
+++ b/apps/backend/tests/song.test.ts
@@ -97,7 +97,7 @@ describe("Song E2E Tests", () => {
 
 			// Verify lyrics were persisted to DB
 			const lyrics = await prisma.lyrics.findMany({
-				where: { songId: data!.id },
+				where: { songId: data?.id },
 			});
 			expect(lyrics).toHaveLength(1);
 			expect(lyrics[0]).toMatchObject({

--- a/apps/backend/tests/song.test.ts
+++ b/apps/backend/tests/song.test.ts
@@ -9,6 +9,7 @@ describe("Song E2E Tests", () => {
 	beforeEach(async () => {
 		await prisma.session.deleteMany();
 		await prisma.user.deleteMany();
+		await prisma.lyrics.deleteMany();
 		await prisma.song.deleteMany();
 	});
 
@@ -62,6 +63,49 @@ describe("Song E2E Tests", () => {
 			expect(status).toBe(401);
 			expect(error?.value).toMatchObject({
 				code: "UNAUTHORIZED",
+			});
+		});
+
+		test("should create a song with lyrics", async () => {
+			const token = await getAuthToken();
+
+			const payload = {
+				name: "Lyrics Song",
+				type: "ORIGINAL" as const,
+				lyrics: [
+					{
+						language: "zh",
+						isTranslated: false,
+						plainText: "第一行歌词\n第二行歌词",
+						lrc: "[00:00.00]第一行歌词\n[00:05.00]第二行歌词",
+						ttml: "<tt></tt>",
+					},
+				],
+			};
+
+			const { data, status } = await api.v2.song.post(payload, {
+				headers: {
+					authorization: `Bearer ${token}`,
+				},
+			});
+
+			expect(status).toBe(201);
+			expect(data).toMatchObject({
+				id: expect.any(Number),
+				name: "Lyrics Song",
+			});
+
+			// Verify lyrics were persisted to DB
+			const lyrics = await prisma.lyrics.findMany({
+				where: { songId: data!.id },
+			});
+			expect(lyrics).toHaveLength(1);
+			expect(lyrics[0]).toMatchObject({
+				language: "zh",
+				isTranslated: false,
+				plainText: "第一行歌词\n第二行歌词",
+				lrc: "[00:00.00]第一行歌词\n[00:05.00]第二行歌词",
+				ttml: "<tt></tt>",
 			});
 		});
 	});

--- a/packages/core/modules/catalog/song/dto.ts
+++ b/packages/core/modules/catalog/song/dto.ts
@@ -16,15 +16,24 @@ const CreatePerformanceSchema = z.object({
 	svsEngineVersionId: z.int().positive().nullish(),
 });
 
+const CreateLyricsSchema = z.object({
+	language: z.string().optional(),
+	isTranslated: z.boolean().optional(),
+	plainText: z.string().optional(),
+	ttml: z.string().optional(),
+	lrc: z.string().optional(),
+});
+
 export const CreateSongRequestSchema = z.object({
 	type: SongTypeSchema.nullish(),
 	name: z.string().nullish(),
-	duration: z.number().nullish(),
+	duration: z.int().nullish(),
 	description: z.string().nullish(),
 	coverUrl: z.url().nullish(),
 	publishedAt: z.iso.datetime().nullish(),
 	performances: z.array(CreatePerformanceSchema).optional(),
 	creations: z.array(CreateCreationSchema).optional(),
+	lyrics: z.array(CreateLyricsSchema).optional(),
 });
 
 export const UpdateSongRequestSchema = z.object({

--- a/packages/core/modules/catalog/song/repository.ts
+++ b/packages/core/modules/catalog/song/repository.ts
@@ -76,7 +76,7 @@ export class SongRepository implements ISongRepository {
 
 	async create(input: CreateSongRequestDto, tx?: TxClient) {
 		const client = tx ?? this.prisma;
-		const { performances, creations, ...songData } = input;
+		const { performances, creations, lyrics, ...songData } = input;
 
 		return transformPrismaResult(
 			await client.song.create({
@@ -95,6 +95,9 @@ export class SongRepository implements ISongRepository {
 							artistId: c.artistId,
 							artistRoleId: c.roleId,
 						})),
+					},
+					lyrics: lyrics && {
+						create: lyrics,
 					},
 				},
 			})


### PR DESCRIPTION
Closes #35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes Made

- **Added lyrics support to Song creation**
  - Created `CreateLyricsSchema` Zod object with fields: `language`, `isTranslated`, `plainText`, `ttml`, `lrc`
  - Extended `CreateSongRequestSchema` to accept an optional `lyrics` array

- **Enhanced SongRepository to handle lyrics relations**
  - Modified `SongRepository.create` to extract and process `lyrics` from the request DTO
  - Added conditional nested `create` operation for lyrics in the Prisma `client.song.create` payload

- **Improved type validation**
  - Changed `duration` field in `CreateSongRequestSchema` from `z.number().nullish()` to `z.int().nullish()` for stricter integer validation

- **Added end-to-end test coverage**
  - Updated test setup to clear `prisma.lyrics` before each test run
  - Added E2E test for `POST /v2/song` with nested lyrics payload
  - Test validates API response (201 status with created song ID and name) and database persistence of lyrics records with matching language, translation status, and content fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->