### PR TITLE
fix(docs page): fix incorrect markdown raw url path

### DIFF
--- a/apps/docs/app/(docs)/[lang]/[[...slug]]/page.tsx
+++ b/apps/docs/app/(docs)/[lang]/[[...slug]]/page.tsx
@@ -56,7 +56,7 @@ export default async function Page({
 				)}
 				<ViewOptionsPopover
 					lang={lang}
-					markdownUrl={`/raw/${currentPage}.mdx`}
+					markdownUrl={`/raw/${lang}/${currentPage}.mdx`}
 					githubUrl={`https://github.com/${gitConfig.user}/${gitConfig.repo}/blob/${gitConfig.branch}/apps/docs/content/${page.path}`}
 				/>
 			</div>

--- a/apps/docs/content/internal/developers/style-guide.md
+++ b/apps/docs/content/internal/developers/style-guide.md
@@ -15,7 +15,7 @@ description: 档案馆项目的代码风格、架构决策及类型安全规范�
         - 其它源码文件使用 `camelCase`（如 `rateLimitPlugin.ts`）
 - **类型声明**:
     - 严禁使用 `any` 与 `z.any()`
-    - 严谨在第一方代码中使用`@ts-ignore`与`@ts-expect-error`
+    - 严禁在第一方代码中使用`@ts-ignore`与`@ts-expect-error`
     - 定义对象结构和类实现时使用 `interface`；定义联合类型、元组或类型别名时使用 `type`。
 - **逻辑组织**:
     - 对于异步操作，统一使用 `async/await`，禁止使用 `.then()` 链式调用。


### PR DESCRIPTION
## Changes
- fix `markdownUrl` leads to 404
- correct typo (style-guide.md#L18)

## Related
- Closes #62 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

- Updated the `markdownUrl` construction in `apps/docs/app/(docs)/[lang]/[[...slug]]/page.tsx` to include the explicit language prefix
  - Changed from `/raw/${currentPage}.mdx` to `/raw/${lang}/${currentPage}.mdx` to match the route structure `/raw/[lang]/[...slug]`
  - Fixes the 404 error on the "View as Markdown" link by ensuring the URL includes the required language parameter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->